### PR TITLE
Bring back throws as log format

### DIFF
--- a/src/Rust.UIFramework/Builder/BaseUiBuilder.Components.cs
+++ b/src/Rust.UIFramework/Builder/BaseUiBuilder.Components.cs
@@ -1,4 +1,5 @@
-﻿using Oxide.Ext.UiFramework.Colors;
+﻿using Oxide.Core;
+using Oxide.Ext.UiFramework.Colors;
 using Oxide.Ext.UiFramework.Controls;
 using Oxide.Ext.UiFramework.Enums;
 using Oxide.Ext.UiFramework.Exceptions;
@@ -97,6 +98,7 @@ namespace Oxide.Ext.UiFramework.Builder
         {
             if (!url.StartsWith("http"))
             {
+                Interface.Oxide.LogWarning($"WebImage Url '{url}' is not a valid url. If trying to use a png id please use {nameof(ImageFileStorage)} instead.");
                 return UiRawImage.CreateDefault(pos, offset);
             }
 
@@ -124,6 +126,7 @@ namespace Oxide.Ext.UiFramework.Builder
         {
             if (!uint.TryParse(png, out uint _))
             {
+                Interface.Oxide.LogWarning($"Image PNG '{png}' is not a valid uint. If trying to use a url please use WebImage instead.");
                 return UiRawImage.CreateDefault(pos, offset);
             }
 


### PR DESCRIPTION
## Proposed changes
Replace the previous throw exceptions with log warnings. Seeing the errors in console would help debug certain image links much faster.