### PR TITLE
Free connections list overload

### DIFF
--- a/src/Rust.UIFramework/Builder/BaseBuilder.cs
+++ b/src/Rust.UIFramework/Builder/BaseBuilder.cs
@@ -25,10 +25,15 @@ namespace Oxide.Ext.UiFramework.Builder
             AddUi(new SendInfo(connection));
         }
 
-        public void AddUi(List<Connection> connections)
+        /// <summary>
+        /// Sends ui to players asynchronously and returns the builder to the pool.
+        /// </summary>
+        /// <param name="connections">All connections to send the ui to.</param>
+        /// <param name="freeConnections">Whether or not to return the connections list to the pool.</param>
+        public void AddUi(List<Connection> connections, bool freeConnections = false)
         {
             if (connections == null) throw new ArgumentNullException(nameof(connections));
-            AddUi(new SendInfo(connections));
+            AddUi(new SendInfo(connections), freeConnections);
         }
 
         public void AddUi()
@@ -37,6 +42,7 @@ namespace Oxide.Ext.UiFramework.Builder
         }
 
         protected abstract void AddUi(SendInfo send);
+        protected abstract void AddUi(SendInfo send, bool freeConnections);
 
         internal void AddUi(SendInfo send, JsonFrameworkWriter writer)
         {

--- a/src/Rust.UIFramework/Builder/BaseBuilder.cs
+++ b/src/Rust.UIFramework/Builder/BaseBuilder.cs
@@ -41,8 +41,7 @@ namespace Oxide.Ext.UiFramework.Builder
             AddUi(new SendInfo(Net.sv.connections));
         }
 
-        protected abstract void AddUi(SendInfo send);
-        protected abstract void AddUi(SendInfo send, bool freeConnections);
+        protected abstract void AddUi(SendInfo send, bool freeConnections = false);
 
         internal void AddUi(SendInfo send, JsonFrameworkWriter writer)
         {

--- a/src/Rust.UIFramework/Builder/BaseUiBuilder.cs
+++ b/src/Rust.UIFramework/Builder/BaseUiBuilder.cs
@@ -48,10 +48,15 @@ namespace Oxide.Ext.UiFramework.Builder
             writer.Dispose();
             return bytes;
         }
-        
+
         protected override void AddUi(SendInfo send)
         {
-            SendUiCallback.Start(this, send);
+            AddUi(send, false);
+        }
+        
+        protected override void AddUi(SendInfo send, bool freeConnections)
+        {
+            SendUiCallback.Start(this, send, freeConnections);
         }
         
         public JsonFrameworkWriter CreateWriter()

--- a/src/Rust.UIFramework/Builder/BaseUiBuilder.cs
+++ b/src/Rust.UIFramework/Builder/BaseUiBuilder.cs
@@ -49,12 +49,7 @@ namespace Oxide.Ext.UiFramework.Builder
             return bytes;
         }
 
-        protected override void AddUi(SendInfo send)
-        {
-            AddUi(send, false);
-        }
-        
-        protected override void AddUi(SendInfo send, bool freeConnections)
+        protected override void AddUi(SendInfo send, bool freeConnections = false)
         {
             SendUiCallback.Start(this, send, freeConnections);
         }

--- a/src/Rust.UIFramework/Builder/Cached/CachedUiBuilder.cs
+++ b/src/Rust.UIFramework/Builder/Cached/CachedUiBuilder.cs
@@ -17,6 +17,6 @@ namespace Oxide.Ext.UiFramework.Builder.Cached
 
         public override byte[] GetBytes() => _cachedJson;
         
-        protected override void AddUi(SendInfo send) => AddUi(send, GetBytes());
+        protected override void AddUi(SendInfo send, bool freeConnections = false) => AddUi(send, GetBytes());
     }
 }

--- a/src/Rust.UIFramework/Callbacks/SendUiCallback.cs
+++ b/src/Rust.UIFramework/Callbacks/SendUiCallback.cs
@@ -10,25 +10,31 @@ public class SendUiCallback : BaseAsyncCallback
 {
     private BaseUiBuilder _builder;
     private SendInfo _send;
-    
-    public static void Start(BaseUiBuilder builder, SendInfo send)
+    private bool _freeConnections;
+
+    public static void Start(BaseUiBuilder builder, SendInfo send, bool freeConnections)
     {
         SendUiCallback callback = UiFrameworkPool.Get<SendUiCallback>();
-        callback.Init(builder, send);
+        callback.Init(builder, send, freeConnections);
         callback.Run();
     }
 
-    private void Init(BaseUiBuilder builder, SendInfo send)
+    private void Init(BaseUiBuilder builder, SendInfo send, bool freeConnections)
     {
         _builder = builder;
         _send = send;
+        _freeConnections = freeConnections;
     }
-    
+
     protected override ValueTask HandleCallback()
     {
         JsonFrameworkWriter writer = _builder.CreateWriter();
         _builder.AddUi(_send, writer);
         writer.Dispose();
+
+        if (_freeConnections && _send.connections != null)
+            Facepunch.Pool.Free(ref _send.connections);
+
         return new ValueTask();
     }
 


### PR DESCRIPTION
## Proposed changes
Create an overload method to return the list of connections to the pool after sending the ui to the players to allow using pooled lists.

## Issue
Since the ui is handled on another thread.. the list of connections is likely to be empty as its been cleared right after calling AddUi() on the main thread.

Steps to reproduce:
1. Fill a pooled list of connections on the main thread
2. Call `builder.AddUi(connections)`
3. Return the list to the pool

## Other
Might not be the best way to implement the solution, but it'd be nice to have a way to use pooled list along side the multithreaded ui.