### PR TITLE
Allow re-using UiBuilder

### DIFF
--- a/src/Rust.UIFramework/Builder/UI/UiBuilder.cs
+++ b/src/Rust.UIFramework/Builder/UI/UiBuilder.cs
@@ -63,10 +63,10 @@ namespace Oxide.Ext.UiFramework.Builder.UI
             return bytes;
         }
 
-        public CachedUiBuilder ToCachedBuilder()
+        public CachedUiBuilder ToCachedBuilder(bool dispose = true)
         {
             CachedUiBuilder cached = CachedUiBuilder.CreateCachedBuilder(this);
-            if (!Disposed)
+            if (dispose && !Disposed)
             {
                 Dispose();
             }


### PR DESCRIPTION
## Proposed changes
Let the user decide whether or not to dispose the UiBuilder converting it to a CachedUiBuilder.

## Use case
Re-using the same UiBuilder to add ui as time goes on and only converting it to a CachedUiBuilder when needed. Meaning x amount of images could be added before converting it instead of converting it each time an image is added.