### PR TITLE
Add `BaseBuilder.DestroyUi(IEnumerable, string)`

### DIFF
--- a/src/Rust.UIFramework/Builder/BaseBuilder.cs
+++ b/src/Rust.UIFramework/Builder/BaseBuilder.cs
@@ -142,6 +142,11 @@ public abstract class BaseBuilder : BasePoolable
             Connections = send
         }, name);
     }
+
+    public static void DestroyUi(IEnumerable<Connection> connections, string name)
+    {
+        DestroyUi(SendInfoBuilder.Get(connections), name);
+    }
     #endregion
 
 #if BENCHMARKS


### PR DESCRIPTION
## Proposed changes
Add a new method that takes an IEnumerable instead of a List<Connection> as a QoL.