### PR TITLE
Fix invalid png missing parent

### DIFF
--- a/src/Rust.UIFramework/Builder/BaseUiBuilder.Components.cs
+++ b/src/Rust.UIFramework/Builder/BaseUiBuilder.Components.cs
@@ -140,13 +140,17 @@ public partial class BaseUiBuilder
         
     public UiRawImage ImageFileStorage(in UiReference parent, in UiPosition pos, in UiOffset offset, string png, UiColor color)
     {
-        if (!uint.TryParse(png, out uint _))
+        UiRawImage image;
+        if (uint.TryParse(png, out uint _))
+        {
+            image = UiRawImage.CreateFileImage(pos, offset, color, png);
+        }
+        else
         {
             Interface.Oxide.LogWarning($"Image PNG '{png}' is not a valid uint. If trying to use a url please use WebImage instead.");
-            return UiRawImage.CreateDefault(pos, offset);
+            image = UiRawImage.CreateDefault(pos, offset);
         }
 
-        UiRawImage image = UiRawImage.CreateFileImage(pos, offset, color, png);
         AddComponent(image, parent);
         return image;
     }


### PR DESCRIPTION
If an image fails to load and returns an invalid png... Using the default image as a parent will throw since the reference was never assigned.
<img width="1260" height="160" alt="image" src="https://github.com/user-attachments/assets/62b4d0f3-a608-43d8-a475-c382df2a6eea" />
